### PR TITLE
fix: keep original snapshot as permanent reference

### DIFF
--- a/mcp_security_tester/proxy/manifest_watcher.py
+++ b/mcp_security_tester/proxy/manifest_watcher.py
@@ -74,7 +74,6 @@ class ManifestWatcher:
                     ],
                 ))
 
-        self._snapshot = current
         return findings
 
     def _hash_tool(self, tool: dict) -> str:


### PR DESCRIPTION
Fixes #15

The snapshot was being overwritten after every diff, meaning gradual rug pulls 
across multiple re-fetches would only get caught on the first change. 
Removed the line that updated the snapshot so the original is always used as the reference.