### PR TITLE
fix: store full response_text in log instead of truncating at 500 chars

### DIFF
--- a/mcp_security_tester/proxy/server.py
+++ b/mcp_security_tester/proxy/server.py
@@ -70,7 +70,7 @@ class MCPSecurityProxy:
                     call = ToolCall(
                         tool_name=name,
                         arguments=arguments or {},
-                        response_text=response_text[:500],
+                        response_text=response_text,
                         duration_ms=duration_ms,
                         findings=output_findings,
                     )


### PR DESCRIPTION
Fixes #16

response_text was being truncated to 500 characters before being stored in the log.
Detection runs on the full content so no threats are missed, but the truncation 
meant log entries were missing evidence for investigation. Now storing the full text.